### PR TITLE
Set comment count to include replies

### DIFF
--- a/src/views/comments/Comments.vue
+++ b/src/views/comments/Comments.vue
@@ -6,7 +6,7 @@
         <div class="flex flex-row flex-wrap pt-3 align-v-center">
             <div class="flex flex-column xs-12 sm-9 mb-3">
                 <h1 class="heading">
-                    {{ totalComments }} Comments
+                    {{ totalCommentsAndReplies }} Comments
                 </h1>
             </div>
 
@@ -286,7 +286,7 @@ export default {
 
                     if (resolved) {
                         this.totalComments = resolved.meta ? resolved.meta.totalResults : resolved.total_results;
-                        // this.totalCommentsAndReplies = resolved['meta']['totalCommentsAndReplies'];
+                        this.totalCommentsAndReplies = resolved.meta ? resolved.meta.totalCommentsAndReplies : this.totalComments;
 
                         if (replace) {
                             this.comments = resolved.data || resolved.results;


### PR DESCRIPTION
Pretty straight-forward, just two lines. To run it locally I used [the "symlink.sh" file described in the docs](https://railroadmedia.github.io/vuesora/#symlinking-vuesora). A random lesson on local for testing: [dev.drumeo.com/members/lessons/course-part/285528](https://dev.drumeo.com/members/lessons/course-part/285528).

One thing I don't get though, is that [for the line above](https://github.com/railroadmedia/vuesora/blob/0.16-comment-count-include-replies/src/views/comments/Comments.vue#L288) if `resolved` is falsy, then `resolved.total_results` is used... but that's not set when I run it.

Maybe it's just out-of-date, maybe if `resolved` is falsy then it's set, or maybe it doesn't matter? I bring it up partially because I didn't know exactly what to do for my line (I just took whatever the totalComments excluding replies was). Also, if it's code-rot then might worth rectifying now.

Asana task: https://app.asana.com/0/1187540529928139/1200071872602471/f

Thank you!